### PR TITLE
Security: bump yajl-ruby to 1.3.1

### DIFF
--- a/pygments.rb.gemspec
+++ b/pygments.rb.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.email = ['aman@tmm1.net']
   s.license = 'MIT'
 
-  s.add_dependency 'yajl-ruby',   '~> 1.2.0'
+  s.add_dependency 'yajl-ruby',   '~> 1.3.1'
   s.add_dependency 'posix-spawn', '~> 0.3.6'
   s.add_development_dependency 'rake-compiler', '~> 0.7.6'
 


### PR DESCRIPTION
Avoid critical vulnerability found in 1.3.0: https://nvd.nist.gov/vuln/detail/CVE-2017-16516